### PR TITLE
Introduce typed StaticMessageObject with validation and Moshi adapter

### DIFF
--- a/model/src/main/kotlin/net/dungeonhub/enums/StaticMessageType.kt
+++ b/model/src/main/kotlin/net/dungeonhub/enums/StaticMessageType.kt
@@ -1,13 +1,31 @@
 package net.dungeonhub.enums
 
 import dev.kordex.i18n.Key
+import net.dungeonhub.model.static_message.StaticMessageObject
+import net.dungeonhub.model.static_message.StaticMessageObjectType
 
-enum class StaticMessageType {
-    ScoreLeaderboard,
-    TotalLeaderboard,
-    ReputationLeaderboard,
-    TicketPanel,
-    PriceMessage;
+enum class StaticMessageType(
+    val linkedObjectType: StaticMessageObjectType?,
+    val supportsSeparators: Boolean = false
+) {
+    ScoreLeaderboard(StaticMessageObjectType.CarryType),
+    TotalLeaderboard(null),
+    ReputationLeaderboard(null),
+    TicketPanel(StaticMessageObjectType.TicketPanel, supportsSeparators = true),
+    PriceMessage(StaticMessageObjectType.CarryTier);
 
     val readableName = Key(name.replace(Regex("([A-Z])"), " $1").trim())
+
+    fun validateObjects(objects: List<StaticMessageObject>) {
+        objects.forEachIndexed { index, entry ->
+            when (entry) {
+                is StaticMessageObject.LinkedObject -> require(entry.type == linkedObjectType) {
+                    "$this only supports linked objects of type $linkedObjectType, but entry $index is ${entry.type}"
+                }
+                StaticMessageObject.Separator -> require(supportsSeparators) {
+                    "$this does not support separators"
+                }
+            }
+        }
+    }
 }

--- a/model/src/main/kotlin/net/dungeonhub/model/static_message/StaticMessageCreationModel.kt
+++ b/model/src/main/kotlin/net/dungeonhub/model/static_message/StaticMessageCreationModel.kt
@@ -8,9 +8,13 @@ class StaticMessageCreationModel(
     val channelId: Long,
     val messageId: Long?,
     val staticMessageType: StaticMessageType,
-    val objectIds: List<Long>,
+    val objects: List<StaticMessageObject>,
     val embedOverride: String?
 ) : CreationModel {
+    init {
+        staticMessageType.validateObjects(objects)
+    }
+
     fun toJson(): String {
         return MoshiService.moshi.adapter(StaticMessageCreationModel::class.java).toJson(this)
     }

--- a/model/src/main/kotlin/net/dungeonhub/model/static_message/StaticMessageModel.kt
+++ b/model/src/main/kotlin/net/dungeonhub/model/static_message/StaticMessageModel.kt
@@ -11,7 +11,7 @@ class StaticMessageModel(
     val channelId: Long,
     val messageId: Long?,
     val staticMessageType: StaticMessageType,
-    val objectIds: List<Long>,
+    val objects: List<StaticMessageObject>,
     val embedOverride: String?,
     val active: Boolean
 ) : UpdateableModel<StaticMessageUpdateModel, StaticMessageModel> {

--- a/model/src/main/kotlin/net/dungeonhub/model/static_message/StaticMessageObject.kt
+++ b/model/src/main/kotlin/net/dungeonhub/model/static_message/StaticMessageObject.kt
@@ -1,0 +1,24 @@
+package net.dungeonhub.model.static_message
+
+/**
+ * An ordered entry in a static message.
+ *
+ * The sealed variants prevent layout entries from being mistaken for linked objects. After checking that an entry is
+ * a [LinkedObject], its [LinkedObject.value] is always available as a non-null object id.
+ */
+sealed interface StaticMessageObject {
+    data class LinkedObject(
+        val type: StaticMessageObjectType,
+        val value: Long
+    ) : StaticMessageObject
+
+    data object Separator : StaticMessageObject
+
+    companion object {
+        fun linkedObject(type: StaticMessageObjectType, value: Long): LinkedObject = LinkedObject(type, value)
+        fun ticketPanel(value: Long): LinkedObject = linkedObject(StaticMessageObjectType.TicketPanel, value)
+        fun carryType(value: Long): LinkedObject = linkedObject(StaticMessageObjectType.CarryType, value)
+        fun carryTier(value: Long): LinkedObject = linkedObject(StaticMessageObjectType.CarryTier, value)
+        fun separator(): Separator = Separator
+    }
+}

--- a/model/src/main/kotlin/net/dungeonhub/model/static_message/StaticMessageObjectJsonAdapter.kt
+++ b/model/src/main/kotlin/net/dungeonhub/model/static_message/StaticMessageObjectJsonAdapter.kt
@@ -1,0 +1,60 @@
+package net.dungeonhub.model.static_message
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+
+/**
+ * Selects the concrete [StaticMessageObject] variant from the `type` discriminator.
+ *
+ * Moshi's reflection adapter handles concrete Kotlin classes, but cannot instantiate the sealed interface used as the
+ * declared list element type. Keeping this adapter also preserves the compact `type`/`value` wire format.
+ */
+class StaticMessageObjectJsonAdapter : JsonAdapter<StaticMessageObject>() {
+    override fun fromJson(reader: JsonReader): StaticMessageObject {
+        var type: String? = null
+        var value: Long? = null
+
+        reader.beginObject()
+        while (reader.hasNext()) {
+            when (reader.nextName()) {
+                "type" -> type = reader.nextString()
+                "value" -> value = reader.nextLong()
+                else -> reader.skipValue()
+            }
+        }
+        reader.endObject()
+
+        if (type == "Separator") {
+            return StaticMessageObject.Separator
+        }
+
+        val objectType = try {
+            StaticMessageObjectType.valueOf(type ?: throw JsonDataException("Static message object type is required"))
+        } catch (exception: IllegalArgumentException) {
+            throw JsonDataException("Unknown static message object type: $type", exception)
+        }
+        return StaticMessageObject.LinkedObject(
+            objectType,
+            value ?: throw JsonDataException("Static message object value is required for type $objectType")
+        )
+    }
+
+    override fun toJson(writer: JsonWriter, value: StaticMessageObject?) {
+        if (value == null) {
+            writer.nullValue()
+            return
+        }
+
+        writer.beginObject()
+        when (value) {
+            is StaticMessageObject.LinkedObject -> {
+                writer.name("type").value(value.type.name)
+                writer.name("value").value(value.value)
+            }
+            StaticMessageObject.Separator -> writer.name("type").value("Separator")
+        }
+        writer.endObject()
+    }
+}

--- a/model/src/main/kotlin/net/dungeonhub/model/static_message/StaticMessageObjectType.kt
+++ b/model/src/main/kotlin/net/dungeonhub/model/static_message/StaticMessageObjectType.kt
@@ -1,0 +1,10 @@
+package net.dungeonhub.model.static_message
+
+/**
+ * Describes the kind of object referenced by a [StaticMessageObject.LinkedObject].
+ */
+enum class StaticMessageObjectType {
+    TicketPanel,
+    CarryType,
+    CarryTier
+}

--- a/model/src/main/kotlin/net/dungeonhub/model/static_message/StaticMessageUpdateModel.kt
+++ b/model/src/main/kotlin/net/dungeonhub/model/static_message/StaticMessageUpdateModel.kt
@@ -1,12 +1,13 @@
 package net.dungeonhub.model.static_message
 
+import net.dungeonhub.enums.StaticMessageType
 import net.dungeonhub.service.MoshiService
 import net.dungeonhub.structure.model.UpdateModel
 
 class StaticMessageUpdateModel(
     var channelId: Long?,
     var messageId: Long?,
-    var objectIds: List<Long>?,
+    var objects: List<StaticMessageObject>?,
     embedOverride: String?,
     var active: Boolean?
 ) : UpdateModel<StaticMessageModel> {
@@ -20,5 +21,11 @@ class StaticMessageUpdateModel(
 
     fun toJson(): String {
         return MoshiService.moshi.adapter(StaticMessageUpdateModel::class.java).toJson(this)
+    }
+
+    /** Validates object changes once the target static message type is known. */
+    fun validateFor(staticMessageType: StaticMessageType): StaticMessageUpdateModel {
+        objects?.let(staticMessageType::validateObjects)
+        return this
     }
 }

--- a/model/src/main/kotlin/net/dungeonhub/service/MoshiService.kt
+++ b/model/src/main/kotlin/net/dungeonhub/service/MoshiService.kt
@@ -10,6 +10,8 @@ import dev.kord.common.entity.Permissions
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
+import net.dungeonhub.model.static_message.StaticMessageObject
+import net.dungeonhub.model.static_message.StaticMessageObjectJsonAdapter
 import java.awt.Color
 import java.time.Instant
 import java.util.*
@@ -17,6 +19,7 @@ import java.util.*
 object MoshiService {
     //TODO add type adapter for kord embeds ?
     val moshi: Moshi = Moshi.Builder()
+        .add(StaticMessageObject::class.java, StaticMessageObjectJsonAdapter())
         .add(Instant::class.java, InstantAdapter())
         .add(Color::class.java, ColorAdapter())
         .add(UUID::class.java, UUIDAdapter())

--- a/model/src/test/kotlin/net/dungeonhub/model/StaticMessageObjectTest.kt
+++ b/model/src/test/kotlin/net/dungeonhub/model/StaticMessageObjectTest.kt
@@ -1,0 +1,225 @@
+package net.dungeonhub.model
+
+import com.squareup.moshi.JsonDataException
+import net.dungeonhub.enums.StaticMessageType
+import net.dungeonhub.model.discord_server.DiscordServerModel
+import net.dungeonhub.model.static_message.StaticMessageCreationModel
+import net.dungeonhub.model.static_message.StaticMessageModel
+import net.dungeonhub.model.static_message.StaticMessageObject
+import net.dungeonhub.model.static_message.StaticMessageObjectType
+import net.dungeonhub.model.static_message.StaticMessageUpdateModel
+import net.dungeonhub.service.MoshiService
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class StaticMessageObjectTest {
+    @Test
+    fun testSupportedLinkedObjectTypes() {
+        assertContentEquals(
+            listOf(
+                StaticMessageObjectType.TicketPanel,
+                StaticMessageObjectType.CarryType,
+                StaticMessageObjectType.CarryTier
+            ),
+            StaticMessageObjectType.entries
+        )
+    }
+
+    @Test
+    fun testStaticMessageTypesDefineTheirObjectRelation() {
+        assertEquals(StaticMessageObjectType.TicketPanel, StaticMessageType.TicketPanel.linkedObjectType)
+        assertEquals(StaticMessageObjectType.CarryType, StaticMessageType.ScoreLeaderboard.linkedObjectType)
+        assertEquals(StaticMessageObjectType.CarryTier, StaticMessageType.PriceMessage.linkedObjectType)
+        assertEquals(null, StaticMessageType.TotalLeaderboard.linkedObjectType)
+        assertEquals(null, StaticMessageType.ReputationLeaderboard.linkedObjectType)
+    }
+
+    @Test
+    fun testTypedObjectsSupportSeparators() {
+        val objects = listOf(
+            StaticMessageObject.ticketPanel(10),
+            StaticMessageObject.ticketPanel(11),
+            StaticMessageObject.separator(),
+            StaticMessageObject.ticketPanel(12)
+        )
+        val model = StaticMessageCreationModel(
+            1,
+            2,
+            StaticMessageType.TicketPanel,
+            objects,
+            null
+        )
+
+        assertEquals(objects, model.objects)
+        assertIs<StaticMessageObject.Separator>(model.objects[2])
+
+        val json = model.toJson()
+        val parsed = MoshiService.moshi.adapter(StaticMessageCreationModel::class.java).fromJson(json)!!
+
+        val linkedObject = assertIs<StaticMessageObject.LinkedObject>(parsed.objects[0])
+        assertEquals(10, linkedObject.value)
+        assertIs<StaticMessageObject.Separator>(parsed.objects[2])
+    }
+
+    @Test
+    fun testUpdateModelCanSendTypedObjects() {
+        val updateModel = StaticMessageUpdateModel(
+            null,
+            null,
+            listOf(StaticMessageObject.ticketPanel(10), StaticMessageObject.separator()),
+            null,
+            null
+        )
+
+        assertIs<StaticMessageObject.Separator>(updateModel.objects!![1])
+        updateModel.validateFor(StaticMessageType.TicketPanel)
+    }
+
+    @Test
+    fun testOnlyTicketPanelsSupportSeparators() {
+        assertEquals(true, StaticMessageType.TicketPanel.supportsSeparators)
+        assertEquals(
+            listOf(
+                StaticMessageType.ScoreLeaderboard,
+                StaticMessageType.TotalLeaderboard,
+                StaticMessageType.ReputationLeaderboard,
+                StaticMessageType.PriceMessage
+            ),
+            StaticMessageType.entries.filterNot(StaticMessageType::supportsSeparators)
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            StaticMessageCreationModel(
+                1,
+                null,
+                StaticMessageType.PriceMessage,
+                listOf(StaticMessageObject.carryTier(10), StaticMessageObject.separator()),
+                null
+            )
+        }
+    }
+
+    @Test
+    fun testStaticMessageRejectsWrongLinkedObjectType() {
+        assertFailsWith<IllegalArgumentException> {
+            StaticMessageCreationModel(
+                1,
+                null,
+                StaticMessageType.ScoreLeaderboard,
+                listOf(StaticMessageObject.carryTier(10)),
+                null
+            )
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            StaticMessageCreationModel(
+                1,
+                null,
+                StaticMessageType.TotalLeaderboard,
+                listOf(StaticMessageObject.carryType(10)),
+                null
+            )
+        }
+    }
+
+    @Test
+    fun testCreationSupportsPreviousIdListUseCases() {
+        val scoreObjects = listOf(3L, 1L, 3L).map { StaticMessageObject.carryType(it) }
+        val priceObjects = listOf(6L, 4L, 6L).map { StaticMessageObject.carryTier(it) }
+
+        val scoreMessage = StaticMessageCreationModel(
+            1,
+            null,
+            StaticMessageType.ScoreLeaderboard,
+            scoreObjects,
+            null
+        )
+        val priceMessage = StaticMessageCreationModel(
+            1,
+            null,
+            StaticMessageType.PriceMessage,
+            priceObjects,
+            null
+        )
+        val totalMessage = StaticMessageCreationModel(
+            1,
+            null,
+            StaticMessageType.TotalLeaderboard,
+            emptyList(),
+            null
+        )
+
+        assertEquals(listOf(3L, 1L, 3L), scoreMessage.objects.map { (it as StaticMessageObject.LinkedObject).value })
+        assertEquals(listOf(6L, 4L, 6L), priceMessage.objects.map { (it as StaticMessageObject.LinkedObject).value })
+        assertEquals(emptyList(), totalMessage.objects)
+    }
+
+    @Test
+    fun testResponseModelAllowsServerDataWithoutValidation() {
+        val serverData = listOf(
+            StaticMessageObject.ticketPanel(10),
+            StaticMessageObject.separator()
+        )
+
+        val model = StaticMessageModel(
+            1,
+            DiscordServerModel(2),
+            3,
+            4,
+            StaticMessageType.PriceMessage,
+            serverData,
+            null,
+            true
+        )
+
+        assertEquals(serverData, model.objects)
+    }
+
+    @Test
+    fun testUpdateObjectsAreValidatedAgainstTargetType() {
+        val updateModel = StaticMessageUpdateModel(
+            null,
+            null,
+            listOf(StaticMessageObject.ticketPanel(10)),
+            null,
+            null
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            updateModel.validateFor(StaticMessageType.PriceMessage)
+        }
+    }
+
+    @Test
+    fun testUpdatePreservesPreviousOptionalAndOrderedIdBehavior() {
+        val omittedObjects = StaticMessageUpdateModel(null, null, null, null, null)
+        omittedObjects.validateFor(StaticMessageType.ScoreLeaderboard)
+
+        val orderedObjects = StaticMessageUpdateModel(
+            null,
+            null,
+            listOf(9L, 7L, 9L).map { StaticMessageObject.carryType(it) },
+            null,
+            null
+        )
+        orderedObjects.validateFor(StaticMessageType.ScoreLeaderboard)
+
+        assertEquals(null, omittedObjects.objects)
+        assertEquals(
+            listOf(9L, 7L, 9L),
+            orderedObjects.objects!!.map { (it as StaticMessageObject.LinkedObject).value }
+        )
+    }
+
+    @Test
+    fun testLinkedObjectRequiresValue() {
+        val adapter = MoshiService.moshi.adapter(StaticMessageObject::class.java)
+
+        assertFailsWith<JsonDataException> {
+            adapter.fromJson("""{"type":"TicketPanel"}""")
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace untyped `objectIds` lists with a typed, ordered representation for static message entries to prevent mixing separators and wrong linked object types.
- Enforce per-message-type constraints (linked object kind and separator support) early when creating or updating static messages.
- Support JSON (de)serialization of the new sealed entry types via Moshi while keeping a compact wire format.

### Description
- Add a sealed `StaticMessageObject` with `LinkedObject` and `Separator` variants and convenience constructors like `ticketPanel`, `carryType`, and `carryTier` in `StaticMessageObject.kt`.
- Add `StaticMessageObjectType` enum describing `TicketPanel`, `CarryType`, and `CarryTier` in `StaticMessageObjectType.kt`.
- Implement `StaticMessageObjectJsonAdapter` to (de)serialize the sealed variants with a `type`/`value` wire format and register it in `MoshiService`.
- Replace `objectIds: List<Long>` with `objects: List<StaticMessageObject>` across `StaticMessageCreationModel`, `StaticMessageModel`, and `StaticMessageUpdateModel`, and apply validation on creation and on update via `StaticMessageType.validateObjects` and `StaticMessageUpdateModel.validateFor`.
- Extend `StaticMessageType` to declare `linkedObjectType: StaticMessageObjectType?` and `supportsSeparators: Boolean` and add `validateObjects` to check entries match the message type constraints.

### Testing
- Added `StaticMessageObjectTest` which covers serialization, model parsing, validation rules, and backward-compatible behaviors; it was run and passed (unit tests executed via `./gradlew :model:test`).
- The new adapter and model changes were exercised by the test suite, and all assertions in `StaticMessageObjectTest` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb3de8d3c83229aa56be4c9dc8ad8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Static messages now support typed linked objects, including ticket panels, carry types, and carry tiers.
  * Separators can be included where supported, preserving message structure and ordering.
  * Static message creation and updates now accept rich object values instead of only numeric IDs.
  * Existing numeric object IDs remain supported during data conversion.

* **Bug Fixes**
  * Added validation for unsupported object types, invalid separators, missing values, and malformed message data with clear errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->